### PR TITLE
Autoreload custom functions, closes #48

### DIFF
--- a/app/hotreload.py
+++ b/app/hotreload.py
@@ -51,7 +51,7 @@ async def start_browser_reload_watcher(sio, directory):
     """Needs to be called from the sio connect event on the backend"""
     global browser_reload_triggered_by_backend
     global watching_frontend_files
-    if not browser_reload_triggered_by_backend:
+    if not browser_reload_triggered_by_backend and not settings.enable_lite:
         await sio.emit("reload")
         browser_reload_triggered_by_backend = True
     if not watching_frontend_files:

--- a/app/hotreload.py
+++ b/app/hotreload.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 from watchfiles import Change, DefaultFilter, awatch
 
+from .config import settings
+
 browser_reload_triggered_by_backend = False
 watching_frontend_files = False
 
@@ -29,8 +31,8 @@ class WebFilter(DefaultFilter):
         if path.suffix in (".html", ".css", ".js"):
             return True
 
-        # Only allow .py files in lite subdirectory
-        if path.suffix in (".py", ".txt", ".env"):
+        # xlwings Lite
+        if settings.enable_lite and path.suffix in (".py", ".txt", ".env"):
             allowed_dirs = ("lite", "custom_scripts", "custom_functions")
             return any(dir_name in path.parts for dir_name in allowed_dirs)
 

--- a/app/static/js/core/custom-functions-code.js
+++ b/app/static/js/core/custom-functions-code.js
@@ -175,7 +175,7 @@ async function base() {
   if (isStreaming) {
     if (socket === null) {
       console.error(
-        "To enable streaming functions, you need to load the socket.io js client before xlwings.min.js and custom-functions-code",
+        "To enable streaming functions, you need to load the socket.io js client before xlwings.js and custom-functions-code",
       );
       return;
     }

--- a/app/static/js/core/reload-custom-functions.js
+++ b/app/static/js/core/reload-custom-functions.js
@@ -1,0 +1,54 @@
+async function reloadCustomFunctions() {
+  // Unofficial API: https://github.com/OfficeDev/office-js/issues/3486
+  await Office.onReady();
+  if (Office.context.requirements.isSetSupported("CustomFunctions", "1.6")) {
+    try {
+      const [metadataResponse, codeResponse] = await Promise.all([
+        fetch(`${config.appPath}/xlwings/custom-functions-meta.json`),
+        fetch(`${config.appPath}/xlwings/custom-functions-code.js`),
+      ]);
+
+      if (!metadataResponse.ok || !codeResponse.ok) {
+        throw new Error("Failed to fetch custom functions data");
+      }
+
+      const jsonMetadataString = await metadataResponse.text();
+      const code = await codeResponse.text();
+
+      await Excel.CustomFunctionManager.register(jsonMetadataString, code);
+    } catch (error) {
+      console.error("Error reloading custom functions:", error);
+    }
+  } else {
+    try {
+      await Excel.run(async (context) => {
+        Excel.CustomFunctionManager.newObject(context).register(
+          jsonMetadataString,
+          code,
+        );
+        await context.sync();
+      });
+    } catch (error) {
+      console.error("Failed to register custom functions:", error);
+    }
+  }
+}
+
+async function retryReloadCustomFunctions(retries, delay) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      await reloadCustomFunctions();
+      // console.log(`Reloaded custom functions code at attempt ${i + 1}`);
+      return;
+    } catch (error) {
+      if (i === retries - 1) throw error;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
+
+(async () => {
+  const maxRetries = 5;
+  const delay = 100;
+  await retryReloadCustomFunctions(maxRetries, delay);
+})();

--- a/app/static/js/core/reload-custom-functions.js
+++ b/app/static/js/core/reload-custom-functions.js
@@ -1,6 +1,8 @@
 async function reloadCustomFunctions() {
   // Unofficial API: https://github.com/OfficeDev/office-js/issues/3486
   await Office.onReady();
+  let jsonMetadataString, code;
+
   if (Office.context.requirements.isSetSupported("CustomFunctions", "1.6")) {
     try {
       const [metadataResponse, codeResponse] = await Promise.all([
@@ -12,8 +14,8 @@ async function reloadCustomFunctions() {
         throw new Error("Failed to fetch custom functions data");
       }
 
-      const jsonMetadataString = await metadataResponse.text();
-      const code = await codeResponse.text();
+      jsonMetadataString = await metadataResponse.text();
+      code = await codeResponse.text();
 
       await Excel.CustomFunctionManager.register(jsonMetadataString, code);
     } catch (error) {

--- a/app/static/js/core/socketio-handlers.js
+++ b/app/static/js/core/socketio-handlers.js
@@ -1,6 +1,7 @@
 // Socket.io
 try {
   globalThis.socket = io({
+    transports: ["websocket", "polling"],
     path: `${config.appPath}/socket.io/`,
     auth: async (callback) => {
       let token = await globalThis.getAuth();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -54,6 +54,7 @@
       {# Load Custom Functions #}
       {% block custom_functions_code %}
         <script src="{{ url_for('custom_functions_code') }}" defer></script>
+        <script src="{{ url_for('static', path='/js/core/reload-custom-functions.js') }}" defer></script>
       {% endblock custom_functions_code %}
       {# Bootstrap with the xlwings theme #}
       {% if settings.enable_bootstrap %}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,17 +1,7 @@
 # Troubleshooting
 
-## Invalid session
-
-You get websocket/socket.io connection errors in the browser dev tools along with something like the following on the server logs:
-
-```none
-Invalid session nms2Du11Yi15GwE2AAAA (further occurrences of this error will be logged with level INFO)
-```
-
-You're most likely running your Socket.io service with multiple workers. This can happen if you set the `XLWINGS_ENVIRONMENT=dev` but are running multiple gunicorn or uvicorn workers. You have to run the Socket.io service with exactly 1 worker, see [`deployment/docker-compose.prod.yaml`](https://github.com/xlwings/xlwings-server/blob/main/deployment/docker-compose.prod.yaml) for an example production setup.
-
 ## Error installing add-ins
 
 When installing the Office.js add-in, you get the following error in the taskbar of Excel: "Addin xlwings Server failed to download a required resource".
 
-Make sure to run your server via https, not via http by using TLS certificates. This also means that you will need to use a domain name, not the IP address directly.
+Solution: Make sure to run your server via https, not via http by using TLS certificates. This also means that you will need to use a domain name, not the IP address directly.

--- a/run.py
+++ b/run.py
@@ -359,7 +359,6 @@ if __name__ == "__main__":
             port=8000,
             reload=True,
             reload_includes=[".env"],
-            reload_excludes=None if not settings.enable_lite else ["**/*.py"],
             ssl_keyfile=ssl_keyfile,
             ssl_certfile=ssl_certfile,
         )


### PR DESCRIPTION
Includes
- a change in socket.io to try websockets before polling
- a fix that was triggering a reload 2x with .py files (introduced with xlwings Lite)