### PR TITLE
Support multiple auth providers

### DIFF
--- a/app/routers/socketio.py
+++ b/app/routers/socketio.py
@@ -39,8 +39,9 @@ async def connect(sid, environ, auth):
             sio=sio, directory=settings.base_dir
         )
     token_string = auth.get("token")
+    provider = auth.get("provider")
     try:
-        current_user = await authenticate(token_string)
+        current_user = await authenticate(token_string, auth_provider=provider)
         await sio.save_session(sid, {"current_user": current_user})
         logger.info(f"Socket.io: connect {sid}")
         logger.info(f"Socket.io: User authenticated {current_user.name}")

--- a/app/static/js/auth.js
+++ b/app/static/js/auth.js
@@ -1,6 +1,13 @@
 globalThis.getAuth = async function () {
   if (config.authProviders.includes("entraid")) {
-    return await xlwings.getAccessToken();
+    const token = await xlwings.getAccessToken();
+    return {
+      token: token,
+      provider: "entraid",
+    };
   }
-  return "";
+  return {
+    token: "",
+    provider: "",
+  };
 };

--- a/app/static/js/core/custom-functions-code.js
+++ b/app/static/js/core/custom-functions-code.js
@@ -215,13 +215,15 @@ async function makeServerCall(body) {
 
   while (attempt < MAX_RETRIES) {
     attempt++;
+    let authResult =
+      typeof globalThis.getAuth === "function"
+        ? await globalThis.getAuth()
+        : { token: "", provider: "" };
     let headers = {
       "Content-Type": "application/json",
-      Authorization:
-        typeof globalThis.getAuth === "function"
-          ? await globalThis.getAuth()
-          : "",
       sid: socket && socket.id ? socket.id.toString() : null,
+      Authorization: authResult.token,
+      "Auth-Provider": authResult.provider,
     };
 
     await semaphore.acquire();

--- a/app/static/js/core/htmx-handlers.js
+++ b/app/static/js/core/htmx-handlers.js
@@ -39,14 +39,14 @@ htmx.on("htmx:responseError", function (event) {
 
 // Task pane authentication (see: https://htmx.org/examples/async-auth/)
 // and bookData handling
-let authToken = null;
+let authResult = null;
 let bookData = null;
 
 htmx.on("htmx:confirm", async (event) => {
   // Block the request until the token is returned
   event.preventDefault();
   // Auth
-  authToken = await globalThis.getAuth();
+  authResult = await globalThis.getAuth();
   // Book
   let element = event.target;
   let includeBook = element.getAttribute("xw-book");
@@ -65,7 +65,8 @@ htmx.on("htmx:confirm", async (event) => {
 });
 
 htmx.on("htmx:configRequest", (event) => {
-  event.detail.headers["Authorization"] = authToken;
+  event.detail.headers["Authorization"] = authResult.token;
+  event.detail.headers["Auth-Provider"] = authResult.provider;
   let element = event.target;
   let includeBook = element.getAttribute("xw-book");
   if (includeBook === "true") {

--- a/app/static/js/core/socketio-handlers.js
+++ b/app/static/js/core/socketio-handlers.js
@@ -4,9 +4,13 @@ try {
     transports: ["websocket", "polling"],
     path: `${config.appPath}/socket.io/`,
     auth: async (callback) => {
-      let token = await globalThis.getAuth();
+      let authResult =
+        typeof globalThis.getAuth === "function"
+          ? await globalThis.getAuth()
+          : { token: "", provider: "" };
       callback({
-        token: token,
+        token: authResult.token,
+        provider: authResult.provider,
       });
     },
   });
@@ -16,11 +20,15 @@ try {
 }
 
 globalThis.socket.on("xlwings:trigger-script", async (data) => {
-  let token = await globalThis.getAuth();
+  let authResult =
+    typeof globalThis.getAuth === "function"
+      ? await globalThis.getAuth()
+      : { token: "", provider: "" };
   xlwings.runPython({
     include: data?.include || "",
     exclude: data?.exclude || "",
-    auth: token,
+    auth: authResult.token,
+    headers: { "Auth-Provider": authResult.provider },
     scriptName: data.script_name,
   });
 });

--- a/app/static/js/core/xlwingsjs/sheet-buttons.js
+++ b/app/static/js/core/xlwingsjs/sheet-buttons.js
@@ -54,10 +54,10 @@ async function registerSheetButton(buttonRef, meta) {
       if (selectedRangeAddress === cellRef && !sheet.isNullObject) {
         const startTime = Date.now();
         try {
-          let token =
+          let authResult =
             typeof globalThis.getAuth === "function"
               ? await globalThis.getAuth()
-              : "";
+              : { token: "", provider: "" };
           if (meta?.show_taskpane) {
             await Office.addin.showAsTaskpane();
           }
@@ -65,7 +65,8 @@ async function registerSheetButton(buttonRef, meta) {
           await xlwings.runPython({
             include: meta?.include || "",
             exclude: meta?.exclude || "",
-            auth: token,
+            auth: authResult.token,
+            headers: { "Auth-Provider": authResult.provider },
             scriptName: scriptName,
           });
         } finally {

--- a/app/static/js/core/xlwingsjs/xlwings.js
+++ b/app/static/js/core/xlwingsjs/xlwings.js
@@ -91,10 +91,10 @@ export async function init() {
       spinner.setAttribute("aria-hidden", "true");
       element.appendChild(spinner);
 
-      let token =
+      let authResult =
         typeof globalThis.getAuth === "function"
           ? await globalThis.getAuth()
-          : "";
+          : { token: "", provider: "" };
       let scriptName = element.getAttribute("xw-click");
 
       // Config
@@ -117,7 +117,8 @@ export async function init() {
       await runPython({
         ...xwConfig,
         scriptName: scriptName,
-        auth: token,
+        auth: authResult.token,
+        headers: { "Auth-Provider": authResult.provider },
         errorDisplayMode: "taskpane",
       });
       element.removeChild(spinner);

--- a/app/static/js/ribbon.js
+++ b/app/static/js/ribbon.js
@@ -2,9 +2,16 @@
 // Needs event.completed() and Office.actions.associate
 // "hello-ribbon" is the identifier in manifest.xml
 async function helloRibbon(event) {
-  let token = await globalThis.getAuth();
   let scriptName = "hello_world";
-  await xlwings.runPython({ auth: token, scriptName: scriptName });
+  let authResult =
+    typeof globalThis.getAuth === "function"
+      ? await globalThis.getAuth()
+      : { token: "", provider: "" };
+  await xlwings.runPython({
+    auth: authResult.token,
+    scriptName: scriptName,
+    headers: { "Auth-Provider": authResult.provider },
+  });
   event.completed();
 }
 Office.actions.associate("hello-ribbon", helloRibbon);


### PR DESCRIPTION
- Provides the `Auth-Provider` header so that the config can be set to e.g., `XLWINGS_AUTH_PROVIDERS=["entraid", "custom"]`
- Fixes socket.io auth for multiple providers, closes #54