### PR TITLE
for dev, cache entraid token in session storage so hotreload doesn't …

### DIFF
--- a/xlwings_server/static/js/entraid.js
+++ b/xlwings_server/static/js/entraid.js
@@ -1,10 +1,30 @@
 // Office.auth.getAccessToken claims that it does everything that this module does,
 // only it doesn't: https://github.com/OfficeDev/office-js/issues/3298
 
+import { config } from "./config.js";
+
+// In dev, the taskpane is reloaded on every hot reload, which fetches a new
+// token each time and quickly hits Entra ID's rate limit. Persist the token in
+// sessionStorage so reloads reuse it until it expires. Never do this in prod.
+const persistToken = config?.environment === "dev";
+const STORAGE_KEY = "xlwingsEntraidToken";
+
 let accessToken = null;
 let isRenewingToken = false;
 let tokenLock = false;
 let tokenExpiry = null;
+
+if (persistToken) {
+  try {
+    const cached = JSON.parse(sessionStorage.getItem(STORAGE_KEY));
+    if (cached) {
+      accessToken = cached.accessToken;
+      tokenExpiry = cached.tokenExpiry;
+    }
+  } catch {
+    // Ignore malformed cache
+  }
+}
 
 function hasKeyExpired() {
   if (!tokenExpiry) {
@@ -34,6 +54,18 @@ async function renewAccessToken() {
     tokenExpiry = decodedPayload.exp;
 
     accessToken = "Bearer " + accessToken;
+
+    if (persistToken) {
+      try {
+        sessionStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify({ accessToken, tokenExpiry }),
+        );
+      } catch {
+        // Caching is best-effort; a storage failure (blocked, quota) must not
+        // overwrite the valid token via the outer catch.
+      }
+    }
   } catch (error) {
     let token_error = `Error ${error.code}: ${error.message}`;
     console.log(token_error);

--- a/xlwings_server/static/js/officejs/taskpane-reload.js
+++ b/xlwings_server/static/js/officejs/taskpane-reload.js
@@ -5,8 +5,8 @@
 // button so the user has an escape if the auto-retries also hang.
 (function () {
   const TIMEOUT_MS = 5000;
-  const STORAGE_KEY = "xlwings.taskpaneReloadCount";
-  const REASON_KEY = "xlwings.taskpaneReloadReason";
+  const STORAGE_KEY = "xlwingsTaskpaneReloadCount";
+  const REASON_KEY = "xlwingsTaskpaneReloadReason";
 
   let reloadAttempts = 0;
   try {


### PR DESCRIPTION
…trigger an api limit, also align sesssion/local storage naming convention